### PR TITLE
Update python examples for f-strings and consistency

### DIFF
--- a/03-fastapi/src/worker.py
+++ b/03-fastapi/src/worker.py
@@ -19,10 +19,8 @@ async def root():
 @app.get("/env")
 async def env(req: Request):
     env = req.scope["env"]
-    return {
-        "message": "Here is an example of getting an environment variable: "
-        + env.MESSAGE
-    }
+    message = f"Here is an example of getting an environment variable: {env.MESSAGE}"
+    return {"message": message}
 
 
 class Item(BaseModel):

--- a/06-vendoring/src/worker.py
+++ b/06-vendoring/src/worker.py
@@ -29,7 +29,5 @@ async def say_hi(name: str):
 @app.get("/env")
 async def env(req: Request):
     env = req.scope["env"]
-    return {
-        "message": "Here is an example of getting an environment variable: "
-        + env.MESSAGE
-    }
+    message = f"Here is an example of getting an environment variable: {env.MESSAGE}"
+    return {"message": message}


### PR DESCRIPTION
1. In example 3 (fastapi), change + concat to f-string and make return consistent with example 6 (vendoring). 
2. In example 6, make routes internally consistent for returns and update /env path to change + concat to f-string