### PR TITLE
Add D1 query example to FastAPI worker sample

### DIFF
--- a/03-fastapi/src/worker.py
+++ b/03-fastapi/src/worker.py
@@ -24,7 +24,22 @@ async def say_hi(name: str):
 async def env(req: Request):
     env = req.scope["env"]
     message = f"Here is an example of getting an environment variable: {env.MESSAGE}"
-    return {"message": message}
+
+    # D1 SQL Database
+    query = "SELECT * FROM users;"
+    results = await env.DB.prepare(query).all()
+
+    users = []
+
+    for result in results.results:
+        users.append({
+            "id": result.id,
+            "name": result.name,
+            "age": result.age
+        }) # This is how to access the <class 'pyodide.ffi.JsProxy'> object.
+
+    return {"message": message, "users": users}
+
 
 
 class Default(WorkerEntrypoint):

--- a/03-fastapi/src/worker.py
+++ b/03-fastapi/src/worker.py
@@ -32,14 +32,11 @@ async def env(req: Request):
     users = []
 
     for result in results.results:
-        users.append({
-            "id": result.id,
-            "name": result.name,
-            "age": result.age
-        }) # This is how to access the <class 'pyodide.ffi.JsProxy'> object.
+        users.append(
+            {"id": result.id, "name": result.name, "age": result.age}
+        )  # This is how to access the <class 'pyodide.ffi.JsProxy'> object.
 
     return {"message": message, "users": users}
-
 
 
 class Default(WorkerEntrypoint):


### PR DESCRIPTION
This PR updates the `03-fastapi` example to show how to access a Cloudflare D1 database from within a FastAPI route in Workers Python.

## What changed

- Extended the `/env` endpoint to include a D1 query example
- Added a sample query using `env.DB.prepare("SELECT * FROM users;").all()`
- Demonstrated how to iterate through `results.results`
- Added an example of converting returned `JsProxy` rows into standard Python dictionaries

## Why

The current example shows how to read an environment variable, but it does not demonstrate how to interact with other Worker bindings such as D1. Since D1 is a common Cloudflare use case, this makes the FastAPI example more practical and useful for users.

## Notes

- This assumes a D1 binding named `DB`
- The example expects a `users` table with fields like `id`, `name`, and `age`