### PR TITLE
Add R2 example

### DIFF
--- a/16-sync-http-clients/README.md
+++ b/16-sync-http-clients/README.md
@@ -1,0 +1,45 @@
+# Sync HTTP Clients Example
+
+This example demonstrates outbound HTTP from a Python Worker using synchronous Python HTTP clients known to work in the current runtime:
+
+- [`requests`](https://pypi.org/project/requests/)
+- [`urllib3`](https://pypi.org/project/urllib3/)
+- [`httpx.Client`](https://www.python-httpx.org/)
+
+It intentionally calls their normal blocking-style APIs from inside the Worker handler.
+
+## How to Run
+
+First ensure that `uv` is installed:
+https://docs.astral.sh/uv/getting-started/installation/#standalone-installer
+
+Run:
+
+```sh
+uv run pywrangler dev
+```
+
+Then try:
+
+```sh
+curl http://localhost:8787/
+curl http://localhost:8787/sync
+```
+
+You can also deploy with:
+
+```sh
+uv run pywrangler deploy
+```
+
+## Endpoints
+
+| Endpoint | Description |
+|---|---|
+| `GET /` | Endpoint index |
+| `GET /sync` | Fetch with `requests.get()`, `urllib3.PoolManager().request()`, and `httpx.Client` |
+| `GET /all` | Alias for `/sync` |
+
+## Notes
+
+This example is limited to synchronous package-backed clients that work in Python Workers. It does not include stdlib raw-socket clients such as `urllib.request` or `http.client`.

--- a/16-sync-http-clients/package.json
+++ b/16-sync-http-clients/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "python-sync-http-clients",
+	"version": "0.0.0",
+	"private": true,
+	"scripts": {
+		"deploy": "uv run pywrangler deploy",
+		"dev": "uv run pywrangler dev",
+		"start": "uv run pywrangler dev"
+	},
+	"devDependencies": {
+		"wrangler": "^4.46.0"
+	}
+}

--- a/16-sync-http-clients/pyproject.toml
+++ b/16-sync-http-clients/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "python-sync-http-clients"
+version = "0.1.0"
+description = "Synchronous HTTP clients in Python Workers"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "httpx>=0.28.0",
+    "requests>=2.32.0",
+    "urllib3>=2.5.0",
+    "workers-runtime-sdk>=1.1.1",
+]
+
+[dependency-groups]
+dev = [
+    "workers-py",
+    "workers-runtime-sdk"
+]

--- a/16-sync-http-clients/src/entry.py
+++ b/16-sync-http-clients/src/entry.py
@@ -26,15 +26,17 @@ class Default(WorkerEntrypoint):
         path = "/" + path.split("?", 1)[0] if path else "/"
 
         if path == "/":
-            return Response.json({
-                "example": "Synchronous HTTP clients in Python Workers",
-                "target": TARGET_URL,
-                "clients": ["requests", "urllib3", "httpx.Client"],
-                "endpoints": {
-                    "GET /sync": "Fetch using requests, urllib3, and httpx.Client",
-                    "GET /all": "Alias for /sync",
-                },
-            })
+            return Response.json(
+                {
+                    "example": "Synchronous HTTP clients in Python Workers",
+                    "target": TARGET_URL,
+                    "clients": ["requests", "urllib3", "httpx.Client"],
+                    "endpoints": {
+                        "GET /sync": "Fetch using requests, urllib3, and httpx.Client",
+                        "GET /all": "Alias for /sync",
+                    },
+                }
+            )
 
         if path in ("/sync", "/all"):
             return Response.json({"target": TARGET_URL, "results": self.fetch_sync()})

--- a/16-sync-http-clients/src/entry.py
+++ b/16-sync-http-clients/src/entry.py
@@ -1,0 +1,74 @@
+import httpx
+import requests
+import urllib3
+from workers import Response, WorkerEntrypoint
+
+TARGET_URL = "https://example.com/"
+EXPECTED_TEXT = "Example Domain"
+
+
+def summarize_result(client, status_code, text, headers=None):
+    """Return a small JSON-safe summary for an outbound HTTP response."""
+    headers = headers or {}
+    return {
+        "client": client,
+        "status_code": int(status_code),
+        "ok": 200 <= int(status_code) < 300,
+        "saw_expected_text": EXPECTED_TEXT in text,
+        "content_type": headers.get("content-type") or headers.get("Content-Type"),
+        "body_preview": text[:80],
+    }
+
+
+class Default(WorkerEntrypoint):
+    async def fetch(self, request):
+        path = request.url.split("/", 3)[-1]
+        path = "/" + path.split("?", 1)[0] if path else "/"
+
+        if path == "/":
+            return Response.json({
+                "example": "Synchronous HTTP clients in Python Workers",
+                "target": TARGET_URL,
+                "clients": ["requests", "urllib3", "httpx.Client"],
+                "endpoints": {
+                    "GET /sync": "Fetch using requests, urllib3, and httpx.Client",
+                    "GET /all": "Alias for /sync",
+                },
+            })
+
+        if path in ("/sync", "/all"):
+            return Response.json({"target": TARGET_URL, "results": self.fetch_sync()})
+
+        return Response.json({"error": "not found"}, status=404)
+
+    def fetch_sync(self):
+        """Use blocking-style Python HTTP clients from a Python Worker."""
+        requests_response = requests.get(TARGET_URL, timeout=10)
+
+        pool = urllib3.PoolManager()
+        urllib3_response = pool.request("GET", TARGET_URL, timeout=10.0)
+        urllib3_text = urllib3_response.data.decode("utf-8")
+
+        with httpx.Client() as client:
+            httpx_response = client.get(TARGET_URL, timeout=10.0)
+
+        return [
+            summarize_result(
+                "requests",
+                requests_response.status_code,
+                requests_response.text,
+                requests_response.headers,
+            ),
+            summarize_result(
+                "urllib3",
+                urllib3_response.status,
+                urllib3_text,
+                urllib3_response.headers,
+            ),
+            summarize_result(
+                "httpx.Client",
+                httpx_response.status_code,
+                httpx_response.text,
+                httpx_response.headers,
+            ),
+        ]

--- a/16-sync-http-clients/wrangler.jsonc
+++ b/16-sync-http-clients/wrangler.jsonc
@@ -1,0 +1,12 @@
+{
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"name": "python-sync-http-clients",
+	"main": "src/entry.py",
+	"compatibility_date": "2025-11-02",
+	"compatibility_flags": [
+		"python_workers"
+	],
+	"observability": {
+		"enabled": true
+	}
+}

--- a/17-r2/README.md
+++ b/17-r2/README.md
@@ -1,0 +1,158 @@
+# R2 Object Storage Example
+
+This example demonstrates how to use the [Cloudflare R2 Workers API](https://developers.cloudflare.com/r2/api/workers/workers-api-reference/) from a Python Worker.
+
+It covers core R2 bucket operations:
+
+- `put()` — upload an object from the request body
+- `get()` — stream an object back to the client
+- `head()` — read object metadata
+- `delete()` — delete one key or a batch of keys
+- `list()` — list objects with `prefix`, `limit`, `cursor`, `delimiter`, and `include`
+- Ranged reads using the `Range` header
+- Conditional `get()` / `put()` via HTTP conditional headers
+- HTTP metadata and custom metadata
+- Optional checksum headers for `put()`
+- Storage class selection via `x-storage-class`
+- Multipart upload with `createMultipartUpload()`, `resumeMultipartUpload()`, `uploadPart()`, `complete()`, and `abort()`
+
+The example keeps binary payloads on the JavaScript side of the runtime where possible. Uploads pass the request `ReadableStream` directly into R2, and downloads pass the R2 object's `ReadableStream` directly into a JavaScript `Response`. This avoids unnecessary JS → Python → JS copies for large objects.
+
+## Shared large-file fixtures
+
+This example defines shared large-file fixtures for streaming demonstrations. These are read-only by convention: upload them out-of-band before using `/large-files/<name>`. The Worker streams them from R2 without reading them into Python memory. The generic `/objects/<key>` and `/multipart?key=<key>` routes still operate on any key you pass them, just like the R2 binding APIs.
+
+| Fixture name | R2 key | Source URL | Used for |
+|---|---|---|---|
+| `hvsc` | `vsc/84/raw/HVSC_84-all-of-them.7z` | Upload out-of-band | Large binary archive streaming fixture |
+| `shakespeare` | `pg100-h.zip` | `https://www.gutenberg.org/cache/epub/100/pg100-h.zip` | Large public ZIP streaming fixture |
+
+## Setup
+
+First ensure that `uv` is installed:
+https://docs.astral.sh/uv/getting-started/installation/#standalone-installer
+
+Create the R2 bucket used by `wrangler.jsonc`:
+
+```sh
+uv run pywrangler r2 bucket create python-r2-example
+```
+
+For local development, run:
+
+```sh
+uv run pywrangler dev
+```
+
+You can also deploy with:
+
+```sh
+uv run pywrangler deploy
+```
+
+## Try it
+
+Upload an object with metadata:
+
+```sh
+curl -X PUT http://localhost:8787/objects/hello.txt \
+  -H 'content-type: text/plain' \
+  -H 'cache-control: public, max-age=60' \
+  -H 'x-object-category: demo' \
+  --data 'Hello from R2 and Python Workers!'
+```
+
+Fetch it:
+
+```sh
+curl -i http://localhost:8787/objects/hello.txt
+```
+
+Fetch only a byte range:
+
+```sh
+curl -i http://localhost:8787/objects/hello.txt -H 'range: bytes=0-4'
+```
+
+Inspect metadata:
+
+```sh
+curl -I http://localhost:8787/objects/hello.txt
+```
+
+Use conditional reads or writes:
+
+```sh
+curl -i http://localhost:8787/objects/hello.txt -H 'if-none-match: "some-etag"'
+curl -X PUT http://localhost:8787/objects/hello.txt -H 'if-match: "some-etag"' --data 'conditional write'
+```
+
+List objects:
+
+```sh
+curl 'http://localhost:8787/objects?prefix=hello&limit=10&include=httpMetadata,customMetadata'
+curl 'http://localhost:8787/objects?delimiter=/'
+```
+
+Batch-delete objects:
+
+```sh
+curl -X DELETE http://localhost:8787/objects \
+  -H 'content-type: application/json' \
+  --data '{"keys":["hello.txt","other.txt"]}'
+```
+
+Check and stream shared large files:
+
+```sh
+# List shared large-file fixtures.
+curl http://localhost:8787/large-files
+
+# Verify that vsc/84/raw/HVSC_84-all-of-them.7z exists in the bucket.
+curl http://localhost:8787/large-files/hvsc/check
+
+# Stream the R2 object directly back to the client.
+curl -o HVSC_84-all-of-them.7z http://localhost:8787/large-files/hvsc
+
+# Verify and stream the Gutenberg ZIP fixture.
+curl http://localhost:8787/large-files/shakespeare/check
+curl -o pg100-h.zip http://localhost:8787/large-files/shakespeare
+
+# Range requests work for large fixture objects too.
+curl -i http://localhost:8787/large-files/hvsc -H 'range: bytes=0-1023'
+```
+
+The same objects are available through the generic object route:
+
+```sh
+curl -I http://localhost:8787/objects/vsc/84/raw/HVSC_84-all-of-them.7z
+curl -I http://localhost:8787/objects/pg100-h.zip
+```
+
+Multipart upload flow for any key, including keys with slashes:
+
+```sh
+# 1. Create the multipart upload and note the uploadId.
+curl -X POST 'http://localhost:8787/multipart?key=archives/big.bin'
+
+# 2. Upload parts. Each response includes the partNumber and etag.
+curl -X PUT 'http://localhost:8787/multipart/<uploadId>/1?key=archives/big.bin' --data-binary @part-1.bin
+curl -X PUT 'http://localhost:8787/multipart/<uploadId>/2?key=archives/big.bin' --data-binary @part-2.bin
+
+# 3. Complete with the uploaded part descriptors.
+curl -X POST 'http://localhost:8787/multipart/<uploadId>/complete?key=archives/big.bin' \
+  -H 'content-type: application/json' \
+  --data '{"parts":[{"partNumber":1,"etag":"<etag-1>"},{"partNumber":2,"etag":"<etag-2>"}]}'
+
+# Or abort the upload.
+curl -X DELETE 'http://localhost:8787/multipart/<uploadId>?key=archives/big.bin'
+```
+
+## Python Worker notes
+
+Cloudflare bindings are JavaScript objects exposed to Python through Pyodide. This example follows these Python Worker patterns:
+
+- Convert Python dicts with `to_js(..., dict_converter=Object.fromEntries)` before passing them to R2 options.
+- Treat JS `null` and `undefined` as missing values at the boundary.
+- Do not read large R2 objects into Python bytes just to return them to the client; pass `obj.body` directly to `js.Response`.
+- Use `request.js_object.body` when passing a request body directly to R2.

--- a/17-r2/package.json
+++ b/17-r2/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "python-r2",
+	"version": "0.0.0",
+	"private": true,
+	"scripts": {
+		"deploy": "uv run pywrangler deploy",
+		"dev": "uv run pywrangler dev",
+		"start": "uv run pywrangler dev"
+	},
+	"devDependencies": {
+		"wrangler": "^4.46.0"
+	}
+}

--- a/17-r2/pyproject.toml
+++ b/17-r2/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "python-r2"
+version = "0.1.0"
+description = "Cloudflare R2 example for Python Workers"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = []
+
+[dependency-groups]
+dev = [
+    "workers-py",
+    "workers-runtime-sdk"
+]

--- a/17-r2/src/entry.py
+++ b/17-r2/src/entry.py
@@ -1,0 +1,571 @@
+from urllib.parse import unquote
+
+from js import Headers, Object, Response as JsResponse, URL
+from pyodide.ffi import jsnull, to_js
+from workers import Response, WorkerEntrypoint
+
+
+BUCKET_BINDING = "BUCKET"
+LARGE_FILES = {
+    "hvsc": {
+        "key": "vsc/84/raw/HVSC_84-all-of-them.7z",
+        "source_url": None,
+        "description": "HVSC 84 archive fixture",
+    },
+    "shakespeare": {
+        "key": "pg100-h.zip",
+        "source_url": "https://www.gutenberg.org/cache/epub/100/pg100-h.zip",
+        "description": "Project Gutenberg Shakespeare ZIP fixture",
+    },
+}
+
+CHECKSUM_HEADERS = {
+    "x-content-md5": "md5",
+    "x-content-sha1": "sha1",
+    "x-content-sha256": "sha256",
+    "x-content-sha384": "sha384",
+    "x-content-sha512": "sha512",
+}
+CONDITIONAL_HEADERS = [
+    "if-match",
+    "if-none-match",
+    "if-modified-since",
+    "if-unmodified-since",
+]
+
+
+def to_js_object(value):
+    """Convert Python dicts to plain JS Objects, not JS Maps."""
+    return to_js(value, dict_converter=Object.fromEntries)
+
+
+def is_missing(value):
+    """True for JS null or undefined values crossing into Python."""
+    if value is None or value is jsnull:
+        return True
+    return str(type(value)) == "<class 'pyodide.ffi.JsProxy'>" and str(value) == "undefined"
+
+
+def json_response(data, status=200):
+    return Response.json(data, status=status)
+
+
+def get_query_param(url, name, default=None):
+    value = url.searchParams.get(name)
+    return default if is_missing(value) else str(value)
+
+
+def require_key(url):
+    key = get_query_param(url, "key")
+    if not key:
+        return None, json_response({"error": "missing key query parameter"}, status=400)
+    return key, None
+
+
+def public_large_files():
+    return {
+        name: {
+            "key": info["key"],
+            "source_url": info["source_url"],
+            "description": info["description"],
+            "read": f"GET /large-files/{name}",
+            "head": f"HEAD /large-files/{name}",
+            "check": f"GET /large-files/{name}/check",
+        }
+        for name, info in LARGE_FILES.items()
+    }
+
+
+def large_file_by_name(name):
+    return LARGE_FILES.get(name)
+
+
+def maybe_conditional_headers(request):
+    """Return request headers for R2 onlyIf when conditional headers are present."""
+    for header in CONDITIONAL_HEADERS:
+        if request.headers.get(header):
+            return request.js_object.headers
+    return None
+
+
+def r2_object_summary(obj):
+    """Convert an R2 object/head result into JSON-safe Python data."""
+    if is_missing(obj):
+        return None
+
+    custom_metadata = getattr(obj, "customMetadata", None)
+    if custom_metadata is not None and hasattr(custom_metadata, "to_py"):
+        custom_metadata = custom_metadata.to_py()
+    elif is_missing(custom_metadata):
+        custom_metadata = {}
+
+    http_metadata = getattr(obj, "httpMetadata", None)
+    if http_metadata is not None and hasattr(http_metadata, "to_py"):
+        http_metadata = http_metadata.to_py()
+    elif is_missing(http_metadata):
+        http_metadata = {}
+
+    checksums_proxy = getattr(obj, "checksums", None)
+    checksums = {}
+    if not is_missing(checksums_proxy):
+        for name in ("md5", "sha1", "sha256", "sha384", "sha512"):
+            checksum = getattr(checksums_proxy, name, None)
+            if not is_missing(checksum):
+                checksums[name] = str(checksum)
+
+    uploaded = getattr(obj, "uploaded", None)
+
+    return {
+        "key": str(obj.key),
+        "version": str(getattr(obj, "version", "")),
+        "size": int(obj.size),
+        "etag": str(obj.etag),
+        "httpEtag": str(getattr(obj, "httpEtag", "")),
+        "uploaded": str(uploaded) if not is_missing(uploaded) else None,
+        "httpMetadata": http_metadata,
+        "customMetadata": custom_metadata,
+        "checksums": checksums,
+        "storageClass": None
+        if is_missing(getattr(obj, "storageClass", None))
+        else str(obj.storageClass),
+    }
+
+
+def object_options_from_request(request, include_checksums=False):
+    """Build R2 put/multipart options from request headers."""
+    http_metadata = {}
+    content_type = request.headers.get("content-type")
+    cache_control = request.headers.get("cache-control")
+    content_disposition = request.headers.get("content-disposition")
+    content_encoding = request.headers.get("content-encoding")
+    content_language = request.headers.get("content-language")
+
+    if content_type:
+        http_metadata["contentType"] = content_type
+    if cache_control:
+        http_metadata["cacheControl"] = cache_control
+    if content_disposition:
+        http_metadata["contentDisposition"] = content_disposition
+    if content_encoding:
+        http_metadata["contentEncoding"] = content_encoding
+    if content_language:
+        http_metadata["contentLanguage"] = content_language
+
+    custom_metadata = {}
+    category = request.headers.get("x-object-category")
+    author = request.headers.get("x-object-author")
+    if category:
+        custom_metadata["category"] = category
+    if author:
+        custom_metadata["author"] = author
+
+    options = {}
+    if http_metadata:
+        options["httpMetadata"] = http_metadata
+    if custom_metadata:
+        options["customMetadata"] = custom_metadata
+
+    storage_class = request.headers.get("x-storage-class")
+    if storage_class:
+        options["storageClass"] = storage_class
+
+    only_if = maybe_conditional_headers(request)
+    if only_if is not None:
+        options["onlyIf"] = only_if
+
+    if include_checksums:
+        checksum_count = 0
+        for header, option_name in CHECKSUM_HEADERS.items():
+            value = request.headers.get(header)
+            if value:
+                checksum_count += 1
+                options[option_name] = value
+        if checksum_count > 1:
+            return None, json_response(
+                {"error": "R2 accepts only one checksum algorithm per put()"},
+                status=400,
+            )
+
+    return (to_js_object(options) if options else None), None
+
+
+def range_options_from_header(range_header):
+    """Parse a single HTTP Range header into R2 get options.
+
+    Supports bytes=start-end, bytes=start-, and bytes=-suffix.
+    """
+    if not range_header:
+        return None, None
+    if not range_header.startswith("bytes="):
+        return None, json_response({"error": "only bytes ranges are supported"}, status=400)
+
+    spec = range_header[len("bytes=") :].strip()
+    if "," in spec or "-" not in spec:
+        return None, json_response({"error": "only a single byte range is supported"}, status=400)
+
+    start, end = spec.split("-", 1)
+    try:
+        if start == "":
+            suffix = int(end)
+            if suffix < 0:
+                raise ValueError
+            return {"range": {"suffix": suffix}}, None
+        offset = int(start)
+        if offset < 0:
+            raise ValueError
+        if end == "":
+            return {"range": {"offset": offset}}, None
+        end_number = int(end)
+        if end_number < offset:
+            return None, json_response({"error": "range end must be >= start"}, status=400)
+        return {"range": {"offset": offset, "length": end_number - offset + 1}}, None
+    except ValueError:
+        return None, json_response({"error": "invalid range"}, status=400)
+
+
+def get_options_from_request(request):
+    options, error = range_options_from_header(request.headers.get("range"))
+    if error:
+        return None, error
+    options = options or {}
+
+    only_if = maybe_conditional_headers(request)
+    if only_if is not None:
+        options["onlyIf"] = only_if
+
+    return (to_js_object(options) if options else None), None
+
+
+def object_headers(obj):
+    """Build response headers from R2 HTTP metadata."""
+    headers = Headers.new()
+    obj.writeHttpMetadata(headers)
+    headers.set("etag", obj.httpEtag)
+    headers.set("accept-ranges", "bytes")
+    headers.set("x-r2-key", obj.key)
+    return headers
+
+
+def object_response(obj, is_range=False):
+    """Return an R2 object body without copying it through Python memory."""
+    if is_missing(getattr(obj, "body", None)):
+        return json_response(
+            {
+                "error": "precondition failed; R2 returned object metadata without a body",
+                "object": r2_object_summary(obj),
+            },
+            status=412,
+        )
+
+    headers = object_headers(obj)
+    status = 200
+    if is_range:
+        status = 206
+        obj_range = getattr(obj, "range", None)
+        if not is_missing(obj_range):
+            offset = int(obj_range.offset)
+            length = int(obj_range.length)
+            headers.set("content-length", str(length))
+            headers.set("content-range", f"bytes {offset}-{offset + length - 1}/{int(obj.size)}")
+
+    return JsResponse.new(obj.body, to_js_object({"status": status, "headers": headers}))
+
+
+def head_response(obj):
+    """Return metadata for an R2 object using the R2 head() result."""
+    headers = object_headers(obj)
+    headers.set("content-length", str(int(obj.size)))
+    return JsResponse.new(None, to_js_object({"status": 200, "headers": headers}))
+
+
+class Default(WorkerEntrypoint):
+    async def fetch(self, request):
+        url = URL.new(request.url)
+        path = str(url.pathname)
+        method = str(request.method).upper()
+
+        if method == "OPTIONS":
+            return Response(
+                None,
+                status=204,
+                headers={"allow": "GET, HEAD, PUT, POST, DELETE, OPTIONS"},
+            )
+
+        if path == "/":
+            return json_response(
+                {
+                    "example": "Cloudflare R2 from a Python Worker",
+                    "binding": BUCKET_BINDING,
+                    "large_files": public_large_files(),
+                    "endpoints": {
+                        "PUT /objects/<key>": "Store request body in R2 with metadata, conditionals, checksum, and storage class options",
+                        "GET /objects/<key>": "Stream an R2 object back to the client without copying through Python",
+                        "GET /objects/<key> with Range": "Serve a byte range using R2 range reads",
+                        "HEAD /objects/<key>": "Read object metadata with R2 head()",
+                        "DELETE /objects/<key>": "Delete one object",
+                        "DELETE /objects": "Batch-delete up to 1000 keys from a JSON body",
+                        "GET /objects?prefix=&limit=&cursor=&delimiter=&include=": "List objects with pagination and optional metadata",
+                        "GET /large-files": "List shared large-file fixtures used by this and future examples",
+                        "GET /large-files/<name>": "Stream a shared large-file fixture directly from R2",
+                        "HEAD /large-files/<name>": "Read shared large-file fixture metadata",
+                        "GET /large-files/<name>/check": "Check that a shared large-file fixture exists",
+                        "POST /multipart?key=<key>": "Create a multipart upload for any R2 key, including keys with slashes",
+                        "PUT /multipart/<uploadId>/<partNumber>?key=<key>": "Upload one multipart part",
+                        "POST /multipart/<uploadId>/complete?key=<key>": "Complete a multipart upload",
+                        "DELETE /multipart/<uploadId>?key=<key>": "Abort a multipart upload",
+                    },
+                    "metadata_headers": [
+                        "content-type",
+                        "cache-control",
+                        "content-disposition",
+                        "content-encoding",
+                        "content-language",
+                        "x-object-category",
+                        "x-object-author",
+                        "x-storage-class",
+                    ],
+                    "conditional_headers": CONDITIONAL_HEADERS,
+                    "checksum_headers": list(CHECKSUM_HEADERS.keys()),
+                }
+            )
+
+        if path == "/objects" and method == "GET":
+            return await self.list_objects(url)
+        if path == "/objects" and method == "DELETE":
+            return await self.delete_objects(request)
+
+        if path == "/large-files" and method == "GET":
+            return json_response({"large_files": public_large_files()})
+
+        if path.startswith("/large-files/"):
+            return await self.handle_large_file(path, method, request)
+
+        if path.startswith("/multipart"):
+            return await self.handle_multipart(request, url, path, method)
+
+        if path.startswith("/objects/"):
+            key = unquote(path[len("/objects/") :])
+            if not key:
+                return json_response({"error": "missing object key"}, status=400)
+
+            if method == "PUT":
+                return await self.put_object(request, key)
+            if method in ("GET", "HEAD"):
+                return await self.get_object(request, key, method)
+            if method == "DELETE":
+                await self.env.BUCKET.delete(key)
+                return json_response({"deleted": [key]})
+
+            return json_response({"error": f"method {method} not allowed"}, status=405)
+
+        return json_response({"error": "not found"}, status=404)
+
+    async def handle_large_file(self, path, method, request):
+        """Read shared large-file fixtures without mutating them."""
+        suffix = path[len("/large-files/") :].strip("/")
+        is_check = suffix.endswith("/check")
+        name = suffix[: -len("/check")].strip("/") if is_check else suffix
+        info = large_file_by_name(name)
+        if info is None:
+            return json_response(
+                {
+                    "error": "unknown large file fixture",
+                    "name": name,
+                    "available": list(LARGE_FILES.keys()),
+                },
+                status=404,
+            )
+
+        if is_check:
+            if method != "GET":
+                return json_response({"error": f"method {method} not allowed"}, status=405)
+            return await self.check_large_file(name, info)
+
+        if method not in ("GET", "HEAD"):
+            return json_response({"error": f"method {method} not allowed"}, status=405)
+        return await self.get_object(request, info["key"], method)
+
+    async def check_large_file(self, name, info):
+        """Verify a shared large-file fixture exists without mutating it."""
+        obj = await self.env.BUCKET.head(info["key"])
+        if is_missing(obj):
+            return json_response(
+                {
+                    "exists": False,
+                    "name": name,
+                    "key": info["key"],
+                    "source_url": info["source_url"],
+                    "message": "Large-file fixture is not present in this R2 bucket. Upload it out-of-band before using this route.",
+                },
+                status=404,
+            )
+        return json_response(
+            {
+                "exists": True,
+                "name": name,
+                "source_url": info["source_url"],
+                "object": r2_object_summary(obj),
+            }
+        )
+
+    async def put_object(self, request, key):
+        options, error = object_options_from_request(request, include_checksums=True)
+        if error:
+            return error
+
+        # Pass the raw JavaScript ReadableStream directly to R2.  This avoids
+        # converting request bytes into Python, which is important for binary
+        # objects and large uploads.
+        body = request.js_object.body
+        if options is None:
+            obj = await self.env.BUCKET.put(key, body)
+        else:
+            obj = await self.env.BUCKET.put(key, body, options)
+
+        if is_missing(obj):
+            return json_response(
+                {"stored": False, "key": key, "reason": "put precondition failed"},
+                status=412,
+            )
+        return json_response({"stored": r2_object_summary(obj)}, status=201)
+
+    async def get_object(self, request, key, method):
+        if method == "HEAD":
+            obj = await self.env.BUCKET.head(key)
+            if is_missing(obj):
+                return json_response({"error": "not found", "key": key}, status=404)
+            return head_response(obj)
+
+        get_options, error = get_options_from_request(request)
+        if error:
+            return error
+        if get_options is None:
+            obj = await self.env.BUCKET.get(key)
+        else:
+            obj = await self.env.BUCKET.get(key, get_options)
+
+        if is_missing(obj):
+            return json_response({"error": "not found", "key": key}, status=404)
+
+        return object_response(obj, is_range=request.headers.get("range") is not None)
+
+    async def delete_objects(self, request):
+        body = await request.json()
+        data = body.to_py() if hasattr(body, "to_py") else body
+        keys = data.get("keys") if isinstance(data, dict) else None
+        if not isinstance(keys, list) or not keys:
+            return json_response({"error": "body must be JSON like {'keys': ['a', 'b']}"}, status=400)
+        if len(keys) > 1000:
+            return json_response({"error": "R2 delete() accepts at most 1000 keys"}, status=400)
+
+        await self.env.BUCKET.delete(to_js(keys))
+        return json_response({"deleted": keys})
+
+    async def handle_multipart(self, request, url, path, method):
+        key, error = require_key(url)
+        if error:
+            return error
+
+        parts = [part for part in path[len("/multipart") :].split("/") if part]
+
+        if method == "POST" and not parts:
+            options, error = object_options_from_request(request)
+            if error:
+                return error
+            if options is None:
+                upload = await self.env.BUCKET.createMultipartUpload(key)
+            else:
+                upload = await self.env.BUCKET.createMultipartUpload(key, options)
+            return json_response({"key": str(upload.key), "uploadId": str(upload.uploadId)}, status=201)
+
+        if not parts:
+            return json_response({"error": "missing uploadId"}, status=400)
+
+        upload_id = unquote(parts[0])
+        upload = self.env.BUCKET.resumeMultipartUpload(key, upload_id)
+
+        if method == "PUT" and len(parts) == 2:
+            try:
+                part_number = int(parts[1])
+            except ValueError:
+                return json_response({"error": "partNumber must be an integer"}, status=400)
+
+            options, error = object_options_from_request(request)
+            if error:
+                return error
+            if options is None:
+                uploaded_part = await upload.uploadPart(part_number, request.js_object.body)
+            else:
+                uploaded_part = await upload.uploadPart(part_number, request.js_object.body, options)
+            return json_response(
+                {
+                    "key": key,
+                    "uploadId": upload_id,
+                    "part": {
+                        "partNumber": int(uploaded_part.partNumber),
+                        "etag": str(uploaded_part.etag),
+                    },
+                }
+            )
+
+        if method == "POST" and len(parts) == 2 and parts[1] == "complete":
+            body = await request.json()
+            data = body.to_py() if hasattr(body, "to_py") else body
+            completed = await upload.complete(to_js_object(data.get("parts", [])))
+            return json_response({"completed": r2_object_summary(completed)})
+
+        if method == "DELETE" and len(parts) == 1:
+            await upload.abort()
+            return json_response({"aborted": {"key": key, "uploadId": upload_id}})
+
+        return json_response({"error": "multipart route not found"}, status=404)
+
+    async def list_objects(self, url):
+        options = {}
+        prefix = get_query_param(url, "prefix")
+        cursor = get_query_param(url, "cursor")
+        limit = get_query_param(url, "limit")
+        delimiter = get_query_param(url, "delimiter")
+        include = get_query_param(url, "include")
+
+        if prefix:
+            options["prefix"] = prefix
+        if cursor:
+            options["cursor"] = cursor
+        if limit:
+            try:
+                parsed_limit = int(limit)
+            except ValueError:
+                return json_response({"error": "limit must be an integer"}, status=400)
+            if parsed_limit < 1 or parsed_limit > 1000:
+                return json_response({"error": "limit must be between 1 and 1000"}, status=400)
+            options["limit"] = parsed_limit
+        if delimiter:
+            options["delimiter"] = delimiter
+        if include:
+            values = [value.strip() for value in include.split(",") if value.strip()]
+            allowed = {"httpMetadata", "customMetadata"}
+            if any(value not in allowed for value in values):
+                return json_response(
+                    {"error": "include must be httpMetadata, customMetadata, or both"},
+                    status=400,
+                )
+            options["include"] = values
+
+        listing = await self.env.BUCKET.list(to_js_object(options))
+        objects = [
+            r2_object_summary(listing.objects[i])
+            for i in range(int(listing.objects.length))
+        ]
+        delimited_prefixes = []
+        if hasattr(listing, "delimitedPrefixes") and not is_missing(listing.delimitedPrefixes):
+            delimited_prefixes = list(listing.delimitedPrefixes.to_py())
+
+        return json_response(
+            {
+                "objects": objects,
+                "truncated": bool(listing.truncated),
+                "cursor": None if is_missing(getattr(listing, "cursor", None)) else str(listing.cursor),
+                "delimitedPrefixes": delimited_prefixes,
+            }
+        )

--- a/17-r2/src/entry.py
+++ b/17-r2/src/entry.py
@@ -43,7 +43,10 @@ def is_missing(value):
     """True for JS null or undefined values crossing into Python."""
     if value is None or value is jsnull:
         return True
-    return str(type(value)) == "<class 'pyodide.ffi.JsProxy'>" and str(value) == "undefined"
+    return (
+        str(type(value)) == "<class 'pyodide.ffi.JsProxy'>"
+        and str(value) == "undefined"
+    )
 
 
 def json_response(data, status=200):
@@ -197,11 +200,15 @@ def range_options_from_header(range_header):
     if not range_header:
         return None, None
     if not range_header.startswith("bytes="):
-        return None, json_response({"error": "only bytes ranges are supported"}, status=400)
+        return None, json_response(
+            {"error": "only bytes ranges are supported"}, status=400
+        )
 
     spec = range_header[len("bytes=") :].strip()
     if "," in spec or "-" not in spec:
-        return None, json_response({"error": "only a single byte range is supported"}, status=400)
+        return None, json_response(
+            {"error": "only a single byte range is supported"}, status=400
+        )
 
     start, end = spec.split("-", 1)
     try:
@@ -217,7 +224,9 @@ def range_options_from_header(range_header):
             return {"range": {"offset": offset}}, None
         end_number = int(end)
         if end_number < offset:
-            return None, json_response({"error": "range end must be >= start"}, status=400)
+            return None, json_response(
+                {"error": "range end must be >= start"}, status=400
+            )
         return {"range": {"offset": offset, "length": end_number - offset + 1}}, None
     except ValueError:
         return None, json_response({"error": "invalid range"}, status=400)
@@ -266,9 +275,13 @@ def object_response(obj, is_range=False):
             offset = int(obj_range.offset)
             length = int(obj_range.length)
             headers.set("content-length", str(length))
-            headers.set("content-range", f"bytes {offset}-{offset + length - 1}/{int(obj.size)}")
+            headers.set(
+                "content-range", f"bytes {offset}-{offset + length - 1}/{int(obj.size)}"
+            )
 
-    return JsResponse.new(obj.body, to_js_object({"status": status, "headers": headers}))
+    return JsResponse.new(
+        obj.body, to_js_object({"status": status, "headers": headers})
+    )
 
 
 def head_response(obj):
@@ -378,7 +391,9 @@ class Default(WorkerEntrypoint):
 
         if is_check:
             if method != "GET":
-                return json_response({"error": f"method {method} not allowed"}, status=405)
+                return json_response(
+                    {"error": f"method {method} not allowed"}, status=405
+                )
             return await self.check_large_file(name, info)
 
         if method not in ("GET", "HEAD"):
@@ -454,9 +469,13 @@ class Default(WorkerEntrypoint):
         data = body.to_py() if hasattr(body, "to_py") else body
         keys = data.get("keys") if isinstance(data, dict) else None
         if not isinstance(keys, list) or not keys:
-            return json_response({"error": "body must be JSON like {'keys': ['a', 'b']}"}, status=400)
+            return json_response(
+                {"error": "body must be JSON like {'keys': ['a', 'b']}"}, status=400
+            )
         if len(keys) > 1000:
-            return json_response({"error": "R2 delete() accepts at most 1000 keys"}, status=400)
+            return json_response(
+                {"error": "R2 delete() accepts at most 1000 keys"}, status=400
+            )
 
         await self.env.BUCKET.delete(to_js(keys))
         return json_response({"deleted": keys})
@@ -476,7 +495,9 @@ class Default(WorkerEntrypoint):
                 upload = await self.env.BUCKET.createMultipartUpload(key)
             else:
                 upload = await self.env.BUCKET.createMultipartUpload(key, options)
-            return json_response({"key": str(upload.key), "uploadId": str(upload.uploadId)}, status=201)
+            return json_response(
+                {"key": str(upload.key), "uploadId": str(upload.uploadId)}, status=201
+            )
 
         if not parts:
             return json_response({"error": "missing uploadId"}, status=400)
@@ -488,15 +509,21 @@ class Default(WorkerEntrypoint):
             try:
                 part_number = int(parts[1])
             except ValueError:
-                return json_response({"error": "partNumber must be an integer"}, status=400)
+                return json_response(
+                    {"error": "partNumber must be an integer"}, status=400
+                )
 
             options, error = object_options_from_request(request)
             if error:
                 return error
             if options is None:
-                uploaded_part = await upload.uploadPart(part_number, request.js_object.body)
+                uploaded_part = await upload.uploadPart(
+                    part_number, request.js_object.body
+                )
             else:
-                uploaded_part = await upload.uploadPart(part_number, request.js_object.body, options)
+                uploaded_part = await upload.uploadPart(
+                    part_number, request.js_object.body, options
+                )
             return json_response(
                 {
                     "key": key,
@@ -538,7 +565,9 @@ class Default(WorkerEntrypoint):
             except ValueError:
                 return json_response({"error": "limit must be an integer"}, status=400)
             if parsed_limit < 1 or parsed_limit > 1000:
-                return json_response({"error": "limit must be between 1 and 1000"}, status=400)
+                return json_response(
+                    {"error": "limit must be between 1 and 1000"}, status=400
+                )
             options["limit"] = parsed_limit
         if delimiter:
             options["delimiter"] = delimiter
@@ -558,14 +587,18 @@ class Default(WorkerEntrypoint):
             for i in range(int(listing.objects.length))
         ]
         delimited_prefixes = []
-        if hasattr(listing, "delimitedPrefixes") and not is_missing(listing.delimitedPrefixes):
+        if hasattr(listing, "delimitedPrefixes") and not is_missing(
+            listing.delimitedPrefixes
+        ):
             delimited_prefixes = list(listing.delimitedPrefixes.to_py())
 
         return json_response(
             {
                 "objects": objects,
                 "truncated": bool(listing.truncated),
-                "cursor": None if is_missing(getattr(listing, "cursor", None)) else str(listing.cursor),
+                "cursor": None
+                if is_missing(getattr(listing, "cursor", None))
+                else str(listing.cursor),
                 "delimitedPrefixes": delimited_prefixes,
             }
         )

--- a/17-r2/wrangler.jsonc
+++ b/17-r2/wrangler.jsonc
@@ -1,0 +1,18 @@
+{
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"name": "python-r2",
+	"main": "src/entry.py",
+	"compatibility_date": "2025-11-02",
+	"compatibility_flags": [
+		"python_workers"
+	],
+	"r2_buckets": [
+		{
+			"binding": "BUCKET",
+			"bucket_name": "python-r2-example"
+		}
+	],
+	"observability": {
+		"enabled": true
+	}
+}

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Need to deploy your Worker to Cloudflare? Python Workers are in open beta and ha
 - [**`14-websocket-stream-consumer/`**](14-websocket-stream-consumer) — shows how to use [WebSocket](https://developers.cloudflare.com/workers/runtime-apis/websockets/) to consume a stream of data with Python Workers.
 - [**`15-chatroom/`**](15-chatroom) - A real-time chatroom using WebSocket.
 - [**`16-sync-http-clients/`**](16-sync-http-clients) — demonstrates outbound HTTP with synchronous Python clients (`requests`, `urllib3`, and `httpx.Client`).
+- [**`17-r2/`**](17-r2) — demonstrates core [Cloudflare R2](https://developers.cloudflare.com/r2/) object storage APIs from Python Workers.
 
 
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Need to deploy your Worker to Cloudflare? Python Workers are in open beta and ha
 - [**`13-js-api-pygments/`**](13-js-api-pygments) — shows how to use [Pygments](https://pygments.org/) to highlight code with Python Workers.
 - [**`14-websocket-stream-consumer/`**](14-websocket-stream-consumer) — shows how to use [WebSocket](https://developers.cloudflare.com/workers/runtime-apis/websockets/) to consume a stream of data with Python Workers.
 - [**`15-chatroom/`**](15-chatroom) - A real-time chatroom using WebSocket.
+- [**`16-sync-http-clients/`**](16-sync-http-clients) — demonstrates outbound HTTP with synchronous Python clients (`requests`, `urllib3`, and `httpx.Client`).
 
 
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -110,6 +110,25 @@ def test_07_durable_objects(dev_server):
     assert response.text == "No messages"
 
 
+def test_16_sync_http_clients(dev_server):
+    port = dev_server
+    response = requests.get(f"http://localhost:{port}/sync")
+    assert response.status_code == 200
+
+    results = response.json()["results"]
+    assert [result["client"] for result in results] == [
+        "requests",
+        "urllib3",
+        "httpx.Client",
+    ]
+
+    for result in results:
+        assert result["status_code"] == 200
+        assert result["ok"] is True
+        assert result["saw_expected_text"] is True
+
+
+
 def test_08_cron(dev_server):
     port = dev_server
     response = requests.get(f"http://localhost:{port}")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -110,6 +110,94 @@ def test_07_durable_objects(dev_server):
     assert response.text == "No messages"
 
 
+def test_17_r2(dev_server):
+    port = dev_server
+    base = f"http://localhost:{port}"
+
+    response = requests.get(base)
+    assert response.status_code == 200
+    root = response.json()
+    assert root["example"] == "Cloudflare R2 from a Python Worker"
+    assert root["large_files"]["hvsc"]["key"] == "vsc/84/raw/HVSC_84-all-of-them.7z"
+    assert root["large_files"]["shakespeare"]["key"] == "pg100-h.zip"
+    assert root["large_files"]["shakespeare"]["source_url"] == "https://www.gutenberg.org/cache/epub/100/pg100-h.zip"
+
+    payload = b"Hello from R2 and Python Workers!"
+    response = requests.put(
+        f"{base}/objects/hello.txt",
+        data=payload,
+        headers={
+            "content-type": "text/plain",
+            "cache-control": "public, max-age=60",
+            "x-object-category": "test",
+        },
+    )
+    assert response.status_code == 201
+    stored = response.json()["stored"]
+    assert stored["key"] == "hello.txt"
+    assert stored["size"] == len(payload)
+    assert stored["customMetadata"]["category"] == "test"
+
+    response = requests.get(f"{base}/objects/hello.txt")
+    assert response.status_code == 200
+    assert response.content == payload
+    assert response.headers["content-type"] == "text/plain"
+    assert response.headers["etag"]
+
+    response = requests.get(f"{base}/objects/hello.txt", headers={"range": "bytes=0-4"})
+    assert response.status_code == 206
+    assert response.content == b"Hello"
+    assert response.headers["content-range"] == f"bytes 0-4/{len(payload)}"
+
+    response = requests.head(f"{base}/objects/hello.txt")
+    assert response.status_code == 200
+    assert response.headers["content-length"] == str(len(payload))
+
+    response = requests.get(f"{base}/objects?prefix=hello&include=customMetadata")
+    assert response.status_code == 200
+    assert [obj["key"] for obj in response.json()["objects"]] == ["hello.txt"]
+
+    response = requests.get(f"{base}/objects?delimiter=/")
+    assert response.status_code == 200
+    assert "delimitedPrefixes" in response.json()
+
+    # Multipart routes use ?key= so realistic R2 keys with slashes work.
+    multipart_key = "multipart/slash-key.txt"
+    response = requests.post(f"{base}/multipart", params={"key": multipart_key})
+    assert response.status_code == 201
+    upload_id = response.json()["uploadId"]
+
+    response = requests.put(
+        f"{base}/multipart/{upload_id}/1",
+        params={"key": multipart_key},
+        data=b"multipart body",
+    )
+    assert response.status_code == 200
+    part = response.json()["part"]
+
+    response = requests.post(
+        f"{base}/multipart/{upload_id}/complete",
+        params={"key": multipart_key},
+        json={"parts": [part]},
+    )
+    assert response.status_code == 200
+    assert response.json()["completed"]["key"] == multipart_key
+
+    response = requests.get(f"{base}/objects/{multipart_key}")
+    assert response.status_code == 200
+    assert response.content == b"multipart body"
+
+    response = requests.delete(
+        f"{base}/objects",
+        json={"keys": ["hello.txt", multipart_key]},
+    )
+    assert response.status_code == 200
+    assert sorted(response.json()["deleted"]) == ["hello.txt", multipart_key]
+
+    response = requests.get(f"{base}/objects/hello.txt")
+    assert response.status_code == 404
+
+
 def test_16_sync_http_clients(dev_server):
     port = dev_server
     response = requests.get(f"http://localhost:{port}/sync")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -120,7 +120,10 @@ def test_17_r2(dev_server):
     assert root["example"] == "Cloudflare R2 from a Python Worker"
     assert root["large_files"]["hvsc"]["key"] == "vsc/84/raw/HVSC_84-all-of-them.7z"
     assert root["large_files"]["shakespeare"]["key"] == "pg100-h.zip"
-    assert root["large_files"]["shakespeare"]["source_url"] == "https://www.gutenberg.org/cache/epub/100/pg100-h.zip"
+    assert (
+        root["large_files"]["shakespeare"]["source_url"]
+        == "https://www.gutenberg.org/cache/epub/100/pg100-h.zip"
+    )
 
     payload = b"Hello from R2 and Python Workers!"
     response = requests.put(
@@ -214,7 +217,6 @@ def test_16_sync_http_clients(dev_server):
         assert result["status_code"] == 200
         assert result["ok"] is True
         assert result["saw_expected_text"] is True
-
 
 
 def test_08_cron(dev_server):


### PR DESCRIPTION
## Summary

Adds a Python Workers example for core Cloudflare R2 Workers API operations.

The example demonstrates:

- object upload/download with `put()`, `get()`, and `head()`
- direct request `ReadableStream` uploads to R2
- direct R2 `ReadableStream` responses without copying large objects through Python memory
- range reads
- HTTP metadata and custom metadata
- conditional read/write headers
- checksum and storage class options
- listing with `prefix`, `limit`, `cursor`, `delimiter`, and `include`
- single-key and batch deletes
- multipart upload create/upload/complete/abort using `?key=` so keys with slashes work
- shared large-file fixture routes for future examples

## Dependency

Depends on #79.

This PR assumes #79 adds `16-sync-http-clients`, so this example is numbered `17-r2`. Until #79 merges, this PR's diff may include the preceding sync HTTP example commit as part of the branch history.

## Tests

```sh
python3 -m py_compile 17-r2/src/entry.py
uv run pytest tests/test_examples.py::test_17_r2 -q
uv run ruff check 17-r2 tests/test_examples.py
```
