### PR TITLE
chore: fix incorrect examples

### DIFF
--- a/04-query-d1/wrangler.jsonc
+++ b/04-query-d1/wrangler.jsonc
@@ -6,9 +6,6 @@
 	"compatibility_flags": [
 		"python_workers"
 	],
-	"ai": {
-		"binding": "AI"
-	},
 	"d1_databases": [
 		{
 			"binding": "DB", // i.e. available in your Worker on env.DB

--- a/08-cron/src/entry.py
+++ b/08-cron/src/entry.py
@@ -3,7 +3,7 @@ from workers import WorkerEntrypoint, Response
 
 class Default(WorkerEntrypoint):
     # runs based on "triggers" in wrangler config
-    async def scheduled(self, controller):
+    async def scheduled(self, controller, env, ctx):
         print("Scheduled task has been executed.")
 
     async def fetch(self):

--- a/10-workflows/wrangler.jsonc
+++ b/10-workflows/wrangler.jsonc
@@ -1,6 +1,6 @@
 {
 	"$schema": "node_modules/wrangler/config-schema.json",
-	"name": "python-cron",
+	"name": "python-workflows",
 	"main": "src/entry.py",
 	"compatibility_date": "2025-11-02",
 	"compatibility_flags": [


### PR DESCRIPTION
1. Remove ai binding from d1 example
2. Add missing parameters in cron example
3. Rename project name of workflows example