### PR TITLE
fix: fix langchain example

### DIFF
--- a/05-langchain/.dev.vars
+++ b/05-langchain/.dev.vars
@@ -1,1 +1,0 @@
-API_KEY=abc123

--- a/05-langchain/README.md
+++ b/05-langchain/README.md
@@ -1,10 +1,6 @@
 # LangChain Example
 
-** Currently this example is broken. **
-
-Warning: Python support in Workers is experimental and things will break. This
-example is meant for reference only right now; you should be prepared to update
-your code between now and official release time as APIs may change.
+This example shows how to use LangChain with Cloudflare Workers AI binding.
 
 ## How to Run
 
@@ -15,3 +11,10 @@ Now, if you run `uv run pywrangler dev` within this directory, it should use the
 in `wrangler.jsonc` to run the example.
 
 You can also run `uv run pywrangler deploy` to deploy the example.
+
+Because this example uses a remote Workers AI binding, local development requires
+`npx wrangler login`.
+
+## Notes
+
+- If you want the lower-level direct binding example, see [`09-workers-ai/`](../09-workers-ai).

--- a/05-langchain/pyproject.toml
+++ b/05-langchain/pyproject.toml
@@ -5,12 +5,13 @@ description = "Python langchain example"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "langchain_core",
-    "langchain_openai"
+    "langchain-cloudflare",
+    "langchain-core",
+    "workers-runtime-sdk>=1.6.8",
 ]
 
 [dependency-groups]
 dev = [
     "workers-py",
-    "workers-runtime-sdk"
+    "workers-runtime-sdk",
 ]

--- a/05-langchain/src/worker.py
+++ b/05-langchain/src/worker.py
@@ -1,15 +1,20 @@
+from langchain_cloudflare import ChatCloudflareWorkersAI
+from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import PromptTemplate
-from langchain_openai import OpenAI
 from workers import Response, WorkerEntrypoint
 
 
 class Default(WorkerEntrypoint):
     async def fetch(self, request):
         prompt = PromptTemplate.from_template(
-            "Complete the following sentence: I am a {profession} and "
+            "In one sentence, describe a great day in the life of an {profession}."
         )
-        llm = OpenAI(api_key=self.env.API_KEY)
-        chain = prompt | llm
+        llm = ChatCloudflareWorkersAI(
+            model_name="@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+            binding=self.env.AI,
+            max_tokens=64,
+        )
+        chain = prompt | llm | StrOutputParser()
 
-        res = await chain.ainvoke({"profession": "electrician"})
-        return Response(res.split(".")[0].strip())
+        result = await chain.ainvoke({"profession": "electrician"})
+        return Response.json({"result": result})

--- a/05-langchain/wrangler.jsonc
+++ b/05-langchain/wrangler.jsonc
@@ -2,17 +2,14 @@
 	"$schema": "node_modules/wrangler/config-schema.json",
 	"name": "hello-langchain",
 	"main": "src/worker.py",
-	"compatibility_date": "2025-11-02",
+	"compatibility_date": "2026-07-29",
 	"compatibility_flags": [
 		"python_workers"
 	],
-	"rules": [
-		{
-			"type": "Data",
-			"globs": ["python_modules/**/*.js"],
-			"fallthrough": true
-		}
-	],
+	"ai": {
+		"binding": "AI",
+		"remote": true
+	},
 	"observability": {
 		"enabled": true
 	}

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -73,7 +73,7 @@ def test_04_query_d1(init_db, dev_server):
     ]
 
 
-@pytest.mark.xfail(reason="Not working")
+@pytest.mark.xfail(reason="Requires remote bindings")
 def test_05_langchain(dev_server):
     pass
 


### PR DESCRIPTION
Fixes langchain example and replace it with the one using `langchain-cloudflare` so that users can easily test it locally without any external subscriptions.